### PR TITLE
optional customResolve()

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ import {
 } from 'graphql'
 import _ from 'lodash'
 
-function createSchema (schemaSpec) {
+function createSchema (schemaSpec, customResolve) {
   let schema = schemaSpec.data.__schema
 
   let customTypes = schema.types
@@ -29,7 +29,7 @@ function createSchema (schemaSpec) {
     } else if (typeSpec.kind === 'OBJECT') {
       return new GraphQLObjectType({
         name: typeSpec.name,
-        fields: () => createFields(typeSpec.fields, customTypes)
+        fields: () => createFields(typeSpec.fields, customTypes, customResolve)
       })
     } else {
       throw new Error(`Cannot create type, unknown kind: ${JSON.stringify(typeSpec)}`)
@@ -52,22 +52,22 @@ function findMutationType (schema, customTypes) {
   return _.find(customTypes, {name: schema.mutationType.name})
 }
 
-function createFields (fieldSpecs, customTypes) {
+function createFields (fieldSpecs, customTypes, customResolve) {
   let fields = {}
 
   fieldSpecs.forEach(fieldSpec => {
-    fields[fieldSpec.name] = createField(fieldSpec, customTypes)
+    fields[fieldSpec.name] = createField(fieldSpec, customTypes, customResolve)
   })
 
   return fields
 }
 
-function createField (fieldSpec, customTypes) {
+function createField (fieldSpec, customTypes, customResolve) {
   return {
     description: fieldSpec.description ? fieldSpec.description : undefined,
     type: getType(fieldSpec.type, customTypes),
     args: createArgs(fieldSpec.args, customTypes),
-    resolve: () => null
+    resolve: customResolve ? customResolve(fieldSpec) : () => null
   }
 }
 

--- a/test/schemaFromIntrospectionTest.js
+++ b/test/schemaFromIntrospectionTest.js
@@ -29,9 +29,7 @@ function introspect (schema) {
 }
 
 describe('Schema from Introspection', () => {
-
   it('supports built in scalars', () => {
-
     let schema = new GraphQLSchema({
       query: new GraphQLObjectType({
         name: 'Query',
@@ -62,7 +60,6 @@ describe('Schema from Introspection', () => {
   })
 
   it('supports custom GraphQLObjectType', () => {
-
     let customType = new GraphQLObjectType({
       name: 'CustomType',
       fields: {
@@ -91,7 +88,6 @@ describe('Schema from Introspection', () => {
   })
 
   it('supports custom scalar', () => {
-
     let customScalarType = new GraphQLScalarType({
       name: 'Odd',
       type: GraphQLInt,
@@ -118,7 +114,6 @@ describe('Schema from Introspection', () => {
   })
 
   it('supports list wrapping type', () => {
-
     let customType = new GraphQLObjectType({
       name: 'CustomType',
       fields: {
@@ -155,7 +150,6 @@ describe('Schema from Introspection', () => {
   })
 
   it('supports non null wrapping type', () => {
-
     let customType = new GraphQLObjectType({
       name: 'CustomType',
       fields: {
@@ -193,7 +187,6 @@ describe('Schema from Introspection', () => {
   })
 
   it('supports fields with arguments', () => {
-
     let schema = new GraphQLSchema({
       query: new GraphQLObjectType({
         name: 'Query',
@@ -217,7 +210,6 @@ describe('Schema from Introspection', () => {
   })
 
   it('supports mutation', () => {
-
     let schema = new GraphQLSchema({
       query: new GraphQLObjectType({
         name: 'Query',
@@ -253,7 +245,6 @@ describe('Schema from Introspection', () => {
   })
 
   it('creates a schema that can be queried with no errors', () => {
-
     let customType = new GraphQLObjectType({
       name: 'CustomType',
       fields: {
@@ -288,5 +279,4 @@ describe('Schema from Introspection', () => {
       queryResults.should.not.have.property('errors')
     })
   })
-
 })

--- a/test/schemaFromIntrospectionTest.js
+++ b/test/schemaFromIntrospectionTest.js
@@ -64,7 +64,7 @@ describe('Schema from Introspection', () => {
   it('supports custom GraphQLObjectType', () => {
 
     let customType = new GraphQLObjectType({
-      name: 'Custom Type',
+      name: 'CustomType',
       fields: {
         name: {
           type: GraphQLString,
@@ -120,7 +120,7 @@ describe('Schema from Introspection', () => {
   it('supports list wrapping type', () => {
 
     let customType = new GraphQLObjectType({
-      name: 'Custom Type',
+      name: 'CustomType',
       fields: {
         name: {
           type: GraphQLString,
@@ -157,7 +157,7 @@ describe('Schema from Introspection', () => {
   it('supports non null wrapping type', () => {
 
     let customType = new GraphQLObjectType({
-      name: 'Custom Type',
+      name: 'CustomType',
       fields: {
         name: {
           type: GraphQLString,
@@ -255,7 +255,7 @@ describe('Schema from Introspection', () => {
   it('creates a schema that can be queried with no errors', () => {
 
     let customType = new GraphQLObjectType({
-      name: 'Custom Type',
+      name: 'CustomType',
       fields: {
         name: {
           type: GraphQLString,


### PR DESCRIPTION
This passes a second argument to `createSchema()` that is called with the fieldSpec and returns a resolve() function for each field.

One use-case might be building a proxy for several remote graphQL servers.

Let me know what you think! I can definitely see an argument for this feature being outside the scope of this project, in which case there's no need to merge – we're using this in practice already, only seems fair to give you the option.